### PR TITLE
update nifi version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /exporter/exporter main.go
 
 FROM openjdk:8-jre
 
-ARG NIFI_VERSION=1.11.4
+ARG NIFI_VERSION=1.16.3
 ARG BASE_URL=https://archive.apache.org/dist
 ARG MIRROR_BASE_URL=${MIRROR_BASE_URL:-${BASE_URL}}
 ARG NIFI_TOOLKIT_BINARY_PATH=${NIFI_TOOLKIT_BINARY_PATH:-/nifi/${NIFI_VERSION}/nifi-toolkit-${NIFI_VERSION}-bin.zip}


### PR DESCRIPTION
- Recently we upgraded nifi to `1.16.3` version, and our exporter stop work with the message error bellow:
```
An error has occurred during metrics gathering:

4 error(s) occurred:
* error collecting metric Desc{fqName: "nifi_counter_total", help: "The value of the counter.", constLabels: {}, variableLabels: [node_id id context name]}: Cannot retrieve metrics for node '': Invalid JSON response from NiFi: invalid character '<' looking for beginning of value
* error collecting metric Desc{fqName: "nifi_conn_flow_files_queued", help: "The number of FlowFiles that are currently queued in the connection", constLabels: {}, variableLabels: [node_id connection_name connection_id group_id source_name destination_name]}: Invalid JSON response from NiFi: invalid character '<' looking for beginning of value
* error collecting metric Desc{fqName: "nifi_pg_component_count", help: "The number of components in this process group.", constLabels: {}, variableLabels: [group status]}: Invalid JSON response from NiFi: invalid character '<' looking for beginning of value
* error collecting metric Desc{fqName: "nifi_info", help: "NiFi version info.", constLabels: {}, variableLabels: [node_id version]}: Invalid JSON response from NiFi: invalid character '<' looking for beginning of value
```

- As nifi exporter download a toolkit to collect this metrics we are bumping nifi version, to download correct toolkit version.